### PR TITLE
Use a minimum set of Rails dependencies in Gemfile

### DIFF
--- a/multiverse.gemspec
+++ b/multiverse.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 5"
+  spec.add_dependency "activesupport", ">= 5"
+  spec.add_dependency "activerecord", ">= 5"
+  spec.add_dependency "railties", ">= 5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
By including Multiverse in my API only app, quite a few non-essential dependencies get brought in (eg. ActionCable).

This PR makes it so that only the few Rails components that are actually used by Multiverse are declared as dependencies.