### PR TITLE
Engine support

### DIFF
--- a/lib/multiverse.rb
+++ b/lib/multiverse.rb
@@ -11,7 +11,7 @@ module Multiverse
     end
 
     def db_dir
-      db_dir = "#{Rails.application.config.paths["db"].first}/#{db}"
+      db_dir = "db/#{db}"
       abort "Unknown DB: #{db}" unless Dir.exist?(db_dir)
       db_dir
     end

--- a/lib/multiverse/railtie.rb
+++ b/lib/multiverse/railtie.rb
@@ -48,13 +48,24 @@ module Multiverse
             ActiveRecord::Base.establish_connection
 
             # need this to run again if environment is loaded afterwards
-            Rake::Task["db:load_config"].reenable
+            if Rake::Task.task_defined?("app:db:load_config")
+              Rake::Task["app:db:load_config"].reenable
+            else
+              Rake::Task["db:load_config"].reenable
+            end
           end
         end
       end
 
-      Rake::Task["db:load_config"].enhance do
-        Rake::Task["multiverse:load_config"].execute
+      # Handle engine namespace
+      if Rake::Task.task_defined?("app:db:load_config")
+        Rake::Task["app:db:load_config"].enhance do
+          Rake::Task["app:multiverse:load_config"].execute
+        end
+      else
+        Rake::Task["db:load_config"].enhance do
+          Rake::Task["multiverse:load_config"].execute
+        end
       end
     end
   end


### PR DESCRIPTION
Allows to use multiverse in combination with an engine. I've tried to find the least unexpected way of doing this, while keeping the initial behavior.

The database configuration lives in the main application. This means that when developing an engine locally you'll have to move the configuration from `config/database.yml` to `path/to/dummy/config/database.yml`.

https://github.com/ankane/multiverse/issues/11