### PR TITLE
Inherit from ApplicationRecord

### DIFF
--- a/lib/generators/multiverse/templates/record.rb.tt
+++ b/lib/generators/multiverse/templates/record.rb.tt
@@ -1,4 +1,4 @@
-class <%= name.camelize %>Record < ActiveRecord::Base
+class <%= name.camelize %>Record < ApplicationRecord
   self.abstract_class = true
   establish_connection :"<%= name.underscore %>_#{Rails.env}"
 end


### PR DESCRIPTION
Updates template to inherit from `ApplicationRecord` vs. `ActiveRecord::Base`.