### PR TITLE
Incorrect `db:<operation>` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This creates a `CatalogRecord` class for models to inherit from and adds configu
 Create the database
 
 ```sh
-DB=catalog rails db:create
+DB=catalog rake db:create
 ```
 
 Create a migration
@@ -47,13 +47,13 @@ DB=catalog rails generate migration add_name_to_products
 Run migrations
 
 ```sh
-DB=catalog rails db:migrate
+DB=catalog rake db:migrate
 ```
 
 Rollback
 
 ```sh
-DB=catalog rails db:rollback
+DB=catalog rake db:rollback
 ```
 
 ## Models


### PR DESCRIPTION
`DB=catalog rails db:create` and other `db:<operation>` commands throw an error in Rails 4.2.4.
**`Error: Command 'db:create' not recognised
Did you mean: $ rake db:create ?`**

Instead, `DB=catalog rake db:create` is working fine along with other operations.